### PR TITLE
Transaction support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "doc": "typedoc --tsconfig tsconfig.json src/index.ts",
     "lint": "eslint '**/*.ts'",
     "test": "jest",
+    "test-local": "LOCAL_DYNAMODB_ENDPOINT=http://localhost:8000 npm run test",
     "prettier:check": "prettier -c **/*.ts",
     "prettier:write": "prettier --write **/*.ts",
     "test:watch": "jest --watch"

--- a/src/base/exceptions.ts
+++ b/src/base/exceptions.ts
@@ -12,6 +12,16 @@ export class ConflictException extends VError {
 }
 
 /**
+ * Thrown when a replace or delete request(s) are rejected as part of transaction
+ * that already exists
+ */
+export class TransactionConflictException extends VError {
+  constructor(message: string) {
+    super({ name: 'transaction_conflict.error' }, message);
+  }
+}
+
+/**
  * Thrown when an `_id` value is specified that is not
  * valid (_id values must be a string).
  */
@@ -118,7 +128,7 @@ export class InvalidIndexedFieldValueException extends VError {
 export class InvalidQueryException extends VError {
   constructor(
     message: string,
-    { collection, query }: { collection: string; query: Record<string, unknown> }
+        { collection, query }: { collection: string; query: Record<string, unknown> }
   ) {
     super(
       {
@@ -232,6 +242,17 @@ export class InvalidBatchReplaceDeleteDescriptorException extends VError {
   }
 }
 
+/**
+ * When a TransactGetItems request conflicts with an
+ * ongoing TransactWriteItems operation on one or
+ * more items in the TransactGetItems request
+ */
+export class TransactionCanceledException extends VError {
+  constructor(message: string, info?: Record<string, unknown>) {
+    super({ name: 'transaction_cancelled', info }, message);
+  }
+}
+
 export class InvalidRangeOperatorException extends VError {
   constructor(message: string, operator: string) {
     super({ name: 'invalid_range_operator', info: { operator } }, message);
@@ -241,5 +262,23 @@ export class InvalidRangeOperatorException extends VError {
 export class IndexAccessPatternTypeException extends VError {
   constructor(message: string) {
     super({ name: 'index_access_pattern_type'}, message);
+  }
+}
+
+/**
+ * DynamoDB rejected the request because you retried a request with
+ * a different payload but with an idempotent token that was already used.
+ */
+export class IdempotentParameterMismatchException extends VError {
+  constructor(message: string) {
+    super({ name: 'idempotent_parameter_mismatch' }, message);
+  }
+}
+/**
+ * The transaction with the given request token is already in progress
+ */
+export class TransactionInProgressException extends VError {
+  constructor(message: string) {
+    super({ name: 'transaction_in_progress' }, message);
   }
 }

--- a/src/base/exceptions.ts
+++ b/src/base/exceptions.ts
@@ -128,7 +128,10 @@ export class InvalidIndexedFieldValueException extends VError {
 export class InvalidQueryException extends VError {
   constructor(
     message: string,
-        { collection, query }: { collection: string; query: Record<string, unknown> }
+    {
+      collection,
+      query,
+    }: { collection: string; query: Record<string, unknown> }
   ) {
     super(
       {
@@ -261,7 +264,7 @@ export class InvalidRangeOperatorException extends VError {
 
 export class IndexAccessPatternTypeException extends VError {
   constructor(message: string) {
-    super({ name: 'index_access_pattern_type'}, message);
+    super({ name: 'index_access_pattern_type' }, message);
   }
 }
 
@@ -272,6 +275,16 @@ export class IndexAccessPatternTypeException extends VError {
 export class IdempotentParameterMismatchException extends VError {
   constructor(message: string) {
     super({ name: 'idempotent_parameter_mismatch' }, message);
+  }
+}
+
+/**
+ * Transaction request cannot include multiple operations on one item
+ */
+
+export class TransactionValidationException extends VError {
+  constructor(message: string) {
+    super({ name: 'transaction_validation' }, message);
   }
 }
 /**

--- a/src/debug/debugDynamoTests.ts
+++ b/src/debug/debugDynamoTests.ts
@@ -1,0 +1,15 @@
+import debug from 'debug';
+
+export const DebugTestsNamespace = 'dynaglue:dynamodb:test';
+
+/** @internal */
+const logger = debug(DebugTestsNamespace);
+
+/**
+ * @internal
+ *
+ * Helper for logging dynamo requests
+ */
+export const debugDynamoTests = (message: string, data: unknown): void => {
+  logger('%s: %O', message, data);
+};

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -1,0 +1,2 @@
+export * from './debugDynamo';
+export * from './debugDynamoTests';

--- a/src/operations/replace.ts
+++ b/src/operations/replace.ts
@@ -2,7 +2,7 @@ import { PutItemCommand, PutItemInput } from '@aws-sdk/client-dynamodb';
 import { marshall } from '@aws-sdk/util-dynamodb';
 import { Context } from '../context';
 import { toWrapped, getCollection } from '../base/util';
-import { DocumentWithId } from '../base/common';
+import { DocumentWithId, WrappedDocument } from '../base/common';
 import { createNameMapper, createValueMapper } from '../base/mappers';
 import debugDynamo from '../debug/debugDynamo';
 import { CompositeCondition } from '../base/conditions';
@@ -20,7 +20,7 @@ import { parseCompositeCondition } from '../base/conditions_parser';
  * @param collectionName the collection to update
  * @param value the document to insert or replace
  * @param options options to apply
- * @param options.condition an optional conditional expression that must be satifisfied for the update to proceed
+ * @param options.condition an optional conditional expression that must be satisfied for the update to proceed
  * @returns the inserted / replaced value
  * @throws {CollectionNotFoundException} when the collection is not found
  */
@@ -30,6 +30,41 @@ export async function replace<DocumentType extends DocumentWithId>(
   value: Record<string, unknown>,
   options: { condition?: CompositeCondition } = {}
 ): Promise<DocumentType> {
+  const { request, wrapped } = createReplaceByIdRequest(
+    context,
+    collectionName,
+    value,
+    options
+  );
+
+  debugDynamo('PutItem', request);
+  const command = new PutItemCommand(request);
+  await context.ddb.send(command);
+  return (wrapped as WrappedDocument<DocumentType>).value;
+}
+
+/**
+ * Create a request for Insert or Replace request
+ *
+ * This operation differs from [[insert]] in that it does not check for the existence
+ * of a document with the same `_id` value - it will replace whatever is there.
+ *
+ * @category Mutation
+ *
+ * @param context the context
+ * @param collectionName the collection to update
+ * @param value the document to insert or replace
+ * @param options options to apply
+ * @param options.condition an optional conditional expression that must be satisfied for the update to proceed
+ * @returns the inserted / replaced request @see {PutItemInput}
+ * @throws {CollectionNotFoundException} when the collection is not found
+ */
+export const createReplaceByIdRequest = <DocumentType extends DocumentWithId>(
+  context: Context,
+  collectionName: string,
+  value: Record<string, unknown>,
+  options: { condition?: CompositeCondition } = {}
+): { request: PutItemInput; wrapped: WrappedDocument<DocumentType> } => {
   const collection = getCollection(context, collectionName);
   const wrapped = toWrapped<DocumentType>(collection, value);
 
@@ -44,16 +79,18 @@ export async function replace<DocumentType extends DocumentWithId>(
     });
   }
 
+  const item = marshall(wrapped, {
+    convertEmptyValues: false,
+    removeUndefinedValues: true,
+  });
   const request: PutItemInput = {
     TableName: collection.layout.tableName,
-    Item: marshall(wrapped, { convertEmptyValues: false, removeUndefinedValues: true }),
+    Item: item,
     ReturnValues: 'NONE',
     ConditionExpression: conditionExpression,
     ExpressionAttributeNames: nameMapper.get(),
     ExpressionAttributeValues: valueMapper.get(),
   };
-  debugDynamo('PutItem', request);
-  const command = new PutItemCommand(request);
-  await context.ddb.send(command);
-  return wrapped.value;
-}
+
+  return { request, wrapped };
+};

--- a/src/operations/transact_find_by_ids.ts
+++ b/src/operations/transact_find_by_ids.ts
@@ -1,4 +1,7 @@
-import { TransactGetItem, TransactGetItemsCommand } from '@aws-sdk/client-dynamodb';
+import {
+  TransactGetItem,
+  TransactGetItemsCommand,
+} from '@aws-sdk/client-dynamodb';
 import { convertToAttr, unmarshall } from '@aws-sdk/util-dynamodb';
 import { Context } from '../context';
 import { InvalidFindDescriptorException } from '../base/exceptions';
@@ -72,14 +75,13 @@ export const transactFindByIds = async <DocumentType extends DocumentWithId>(
   const command = new TransactGetItemsCommand(request);
   const { Responses = [] } = await ctx.ddb.send(command);
 
-  const returnedItems = new Array(items.length);
+  const returnedItems = [];
   for (const response of Responses) {
-    let item = null;
     if (response.Item) {
       const unmarshalled = unmarshall(response.Item);
-      item = unwrap(unmarshalled as WrappedDocument<DocumentType>);
+      const item = unwrap(unmarshalled as WrappedDocument<DocumentType>);
+      returnedItems.push(item);
     }
-    returnedItems.push(item);
   }
   return returnedItems;
 };

--- a/src/operations/transact_write.test.ts
+++ b/src/operations/transact_write.test.ts
@@ -1,0 +1,251 @@
+import {
+  CreateTableCommand,
+  CreateTableInput,
+  DeleteTableCommand,
+  DynamoDBClient,
+  ListTablesCommand,
+} from '@aws-sdk/client-dynamodb';
+import { CollectionLayout } from '../base/layout';
+import { createContext } from '../context';
+import { replace } from './replace';
+import {
+  TransactFindByIdDescriptor,
+  transactFindByIds,
+} from './transact_find_by_ids';
+import { TransactionWriteRequest, transactionWrite } from './transact_write';
+import debug from 'debug';
+import { DebugTestsNamespace, debugDynamoTests } from '../debug';
+
+const TableDefinitions = [
+  {
+    TableName: 'User',
+    KeySchema: [
+      { AttributeName: 'pk', KeyType: 'HASH' },
+      { AttributeName: 'sk', KeyType: 'RANGE' },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: 'pk', AttributeType: 'S' },
+      { AttributeName: 'sk', AttributeType: 'S' },
+    ],
+    ProvisionedThroughput: { ReadCapacityUnits: 1, WriteCapacityUnits: 1 },
+  },
+];
+
+const layout: CollectionLayout = {
+  tableName: 'User',
+  primaryKey: { partitionKey: 'pk', sortKey: 'sk' },
+};
+const collection = {
+  name: 'users',
+  layout,
+};
+
+const showTimeTaken = (startTime: number) =>
+  `[${new Date().getTime() - startTime}ms]`;
+
+const LocalDDBTestKit = {
+  connect: (): DynamoDBClient | null => {
+    const startBy = new Date().getTime();
+    try {
+      const localDDBClient = new DynamoDBClient({
+        endpoint: 'http://localhost:8000',
+        region: 'local',
+      });
+      debugDynamoTests(`${showTimeTaken(startBy)} Connected to Local DDB`, '');
+      return localDDBClient;
+    } catch (error) {
+      debugDynamoTests('Error connecting to local DDB', error);
+      return null;
+    }
+  },
+  createTables: async (
+    client: DynamoDBClient,
+    tableDefinitions: CreateTableInput[] = []
+  ) => {
+    const startBy = new Date().getTime();
+    try {
+      await Promise.all(
+        tableDefinitions?.map((tableDefinition) => {
+          const createTableCmd = new CreateTableCommand(tableDefinition);
+          return client.send(createTableCmd);
+        })
+      );
+
+      debugDynamoTests(
+        `${showTimeTaken(startBy)} tables created in local DDB`,
+        ''
+      );
+    } catch (error) {
+      debugDynamoTests('Error creating tables in local DDB', error);
+    }
+  },
+  deleteTables: async (client: DynamoDBClient, tableNames: string[] = []) => {
+    const startBy = new Date().getTime();
+    try {
+      await Promise.all(
+        tableNames?.map((tableName) => {
+          return client.send(
+            new DeleteTableCommand({
+              TableName: tableName,
+            })
+          );
+        })
+      );
+
+      debugDynamoTests(
+        `${showTimeTaken(startBy)} tables deleted in local DDB`,
+        ''
+      );
+    } catch (error) {
+      debugDynamoTests('Error deleting tables in local DDB', error);
+    }
+  },
+  listTables: async (client: DynamoDBClient) => {
+    try {
+      await client.send(new ListTablesCommand({}));
+    } catch (error) {
+      debugDynamoTests('Error listing tables in local DDB', error);
+    }
+  },
+};
+
+describe('transactions', () => {
+  let localDDBClient: DynamoDBClient;
+
+  // create a client with DDB local
+  beforeAll(async () => {
+    debug.enable(DebugTestsNamespace);
+    localDDBClient = LocalDDBTestKit.connect() as unknown as DynamoDBClient;
+  });
+
+  // create tables
+  beforeAll(async () => {
+    await LocalDDBTestKit.createTables(localDDBClient, TableDefinitions);
+  });
+
+  // Delete tables
+  afterAll(async () => {
+    await LocalDDBTestKit.deleteTables(localDDBClient, [
+      TableDefinitions[0].TableName,
+    ]);
+    debug.disable();
+  });
+
+  test.each([
+    { _id: 'test-id', name: 'Moriarty', email: 'moriarty@jim.com' },
+    {
+      _id: 'test-sh',
+      name: 'Sherlock',
+      email: 'sh@sh.com',
+    },
+  ])('Insert items to the collection using replace', async (value) => {
+    const context = createContext(localDDBClient as unknown as DynamoDBClient, [
+      collection,
+    ]);
+
+    const result = await replace(context, collection.name, value, {
+      condition: { _id: { $exists: false } }, // condition to check user doesn't exists
+    });
+    expect(result).toHaveProperty('_id');
+  });
+
+  test('fetch items using transaction', async () => {
+    const context = createContext(localDDBClient as unknown as DynamoDBClient, [
+      collection,
+    ]);
+
+    const items: TransactFindByIdDescriptor[] = [
+      {
+        id: 'test-sh',
+        collection: collection.name,
+      },
+      {
+        id: 'test-id',
+        collection: collection.name,
+      },
+    ];
+    const result = await transactFindByIds(context, items);
+
+    debugDynamoTests(
+      'fetched items using transactFindByIds',
+      JSON.stringify(result)
+    );
+
+    expect(result).toEqual([
+      { name: 'Sherlock', email: 'sh@sh.com', _id: 'test-sh' },
+      { name: 'Moriarty', email: 'moriarty@jim.com', _id: 'test-id' },
+    ]);
+  });
+
+  test('write a transaction to ddb consisting multiple ops', async () => {
+    const context = createContext(localDDBClient as unknown as DynamoDBClient, [
+      collection,
+    ]);
+
+    const request = [
+      {
+        collectionName: collection.name,
+        value: {
+          _id: 'test-jw',
+          lastName: 'Watson',
+          firstName: 'John',
+          email: 'jw@sh.sh',
+        },
+        options: { condition: { _id: { $exists: false } } }, // an insertion
+      },
+      {
+        collectionName: collection.name,
+        value: {
+          _id: 'test-sh',
+          lastName: 'Holmes',
+          firstName: 'Sherlock',
+          email: 'sh@sh.sh',
+        }, // an update to existing user
+      },
+      {
+        collectionName: collection.name,
+        id: 'test-id',
+      }, // a deletion
+    ] as TransactionWriteRequest[];
+
+    transactionWrite(context, request);
+  });
+
+  test('fetch inserted, updated(replaced) or deleted items using transaction', async () => {
+    const context = createContext(localDDBClient as unknown as DynamoDBClient, [
+      collection,
+    ]);
+
+    const items: TransactFindByIdDescriptor[] = [
+      {
+        id: 'test-sh',
+        collection: collection.name,
+      },
+      {
+        id: 'test-jw',
+        collection: collection.name,
+      },
+      {
+        id: 'test-id',
+        collection: collection.name,
+      },
+    ];
+
+    const result = await transactFindByIds(context, items);
+
+    expect(result).toEqual([
+      {
+        lastName: 'Holmes',
+        firstName: 'Sherlock',
+        _id: 'test-sh',
+        email: 'sh@sh.sh',
+      },
+      {
+        lastName: 'Watson',
+        firstName: 'John',
+        _id: 'test-jw',
+        email: 'jw@sh.sh',
+      },
+    ]);
+  });
+});

--- a/src/operations/transact_write.ts
+++ b/src/operations/transact_write.ts
@@ -1,0 +1,134 @@
+import {
+  Delete,
+  Put,
+  TransactWriteItem,
+  TransactWriteItemsCommand,
+} from '@aws-sdk/client-dynamodb';
+import { CompositeCondition } from '../base/conditions';
+import {
+  InvalidFindDescriptorException,
+  TransactionCanceledException,
+  TransactionConflictException,
+} from '../base/exceptions';
+import { Context } from '../context';
+import debugDynamo from '../debug/debugDynamo';
+import { createDeleteByIdRequest } from './delete_by_id';
+import { createReplaceByIdRequest } from './replace';
+
+/**
+ * @param collectionName the collection to update
+ * @param value the document to insert or replace
+ * @param options options to apply
+ * @param options.condition an optional conditional expression that must be satisfied for the update to proceed
+ */
+export type TransactionReplaceRequest = {
+  collectionName: string;
+  value: Record<string, unknown>;
+  options?: { condition?: CompositeCondition };
+};
+
+/**
+ * @param collectionName the collection to update
+ * @param id the document to delete
+ * @param options options to apply
+ * @param options.condition an optional conditional expression that must be satisfied for the update to proceed
+ */
+export type TransactionDeleteRequest = {
+  collectionName: string;
+  id: string;
+  options?: { condition?: CompositeCondition };
+};
+
+export type TransactionWriteRequest =
+  | TransactionReplaceRequest
+  | TransactionDeleteRequest;
+
+const isTransactionReplaceRequest = (
+  transactionWriteRequest: TransactionWriteRequest
+): transactionWriteRequest is TransactionReplaceRequest =>
+  'value' in transactionWriteRequest && !!transactionWriteRequest.value;
+
+const isTransactionDeleteRequest = (
+  transactionWriteRequest: TransactionDeleteRequest
+): transactionWriteRequest is TransactionDeleteRequest =>
+  'id' in transactionWriteRequest && !!transactionWriteRequest.id;
+
+/**
+ * This operation writes to DynamoDB in a transaction.
+ * A transaction can contain upto 25 operations (Insert, Replace or Delete)
+ *
+ * @category Mutation
+ *
+ * @param context
+ * @param transactionWriteRequests
+ * @throws {TransactionCanceledException}
+ * @throws {TransactionConflictException}
+ */
+export const transactionWrite = async (
+  context: Context,
+  transactionWriteRequests: TransactionWriteRequest[]
+): Promise<void> => {
+  if (!transactionWriteRequests || transactionWriteRequests.length === 0) {
+    throw new InvalidFindDescriptorException(
+      'At least one request should be provided'
+    );
+  } else if (transactionWriteRequests.length > 25) {
+    throw new InvalidFindDescriptorException(
+      'No more than 25 requests can be specified to transactionWrite'
+    );
+  }
+  const transactWriteItem: TransactWriteItem[] = transactionWriteRequests.map(
+    (request) => {
+      /** Checks and create a REPLACE request for a requested item */
+      if (isTransactionReplaceRequest(request)) {
+        const { collectionName, value, options } = request;
+        const { request: putItemInput } = createReplaceByIdRequest(
+          context,
+          collectionName,
+          value,
+          options
+        );
+
+        return { Put: putItemInput } as { Put: Put };
+      }
+
+      /** Checks and create a DELETE request for a requested item */
+      if (isTransactionDeleteRequest(request)) {
+        const { collectionName, id, options } = request;
+
+        const deleteItem = createDeleteByIdRequest(
+          context,
+          collectionName,
+          id,
+          options
+        );
+
+        return { Delete: deleteItem } as { Delete: Delete };
+      }
+    }
+  ) as unknown as TransactWriteItem[];
+
+  try {
+    const request = { TransactItems: transactWriteItem };
+
+    debugDynamo('transactWriteItems', JSON.stringify(request));
+
+    const command = new TransactWriteItemsCommand(request);
+    await context.ddb.send(command);
+  } catch (error) {
+    console.error('Error in writing transactions to DynamoDB : ', error);
+
+    // ToDo :: below 2 can be merged
+    if ((error as Error).name === 'TransactionCanceledException') {
+      throw new TransactionCanceledException(
+        'The entire transaction request was canceled'
+      );
+    }
+    if ((error as Error).name === 'TransactionConflictException') {
+      throw new TransactionConflictException(
+        'Another transaction or request is in progress for one of the requested item'
+      );
+    }
+    throw error;
+  }
+};

--- a/src/operations/transact_write.ts
+++ b/src/operations/transact_write.ts
@@ -9,6 +9,7 @@ import {
   InvalidFindDescriptorException,
   TransactionCanceledException,
   TransactionConflictException,
+  TransactionValidationException,
 } from '../base/exceptions';
 import { Context } from '../context';
 import debugDynamo from '../debug/debugDynamo';
@@ -118,7 +119,11 @@ export const transactionWrite = async (
   } catch (error) {
     console.error('Error in writing transactions to DynamoDB : ', error);
 
-    // ToDo :: below 2 can be merged
+    if ((error as Error).name === 'ValidationException') {
+      throw new TransactionValidationException(
+        'Multiple operations are included for same item id'
+      );
+    }
     if ((error as Error).name === 'TransactionCanceledException') {
       throw new TransactionCanceledException(
         'The entire transaction request was canceled'


### PR DESCRIPTION
This Release supports the Transaction to Write Items to Dynamo DB.

At the moment only operations that are supported on transaction are `PutItem` and `DeleteItem` for `TransactWriteItems`. `GetItem` for `TransactGetItems`.

Adding Idempotent transaction is planned for next alpha version