### PR TITLE
Added TransactionWrite support for Delete and Put items

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "doc": "typedoc --tsconfig tsconfig.json src/index.ts",
     "lint": "eslint '**/*.ts'",
     "test": "jest",
+    "test-local": "LOCAL_DYNAMODB_ENDPOINT=http://localhost:8000 npm run test",
     "prettier:check": "prettier -c **/*.ts",
     "prettier:write": "prettier --write **/*.ts",
     "test:watch": "jest --watch"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "dynaglue",
-  "version": "1.1.1",
+  "version": "1.2.0-aplha.1",
   "description": "dynaglue",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This Release supports the Transaction to Write Items to Dynamo DB.

At the moment only operations that are supported on transaction are `PutItem` and `DeleteItem` for `TransactWriteItems`. `GetItem` for `TransactGetItems`.

Adding Idempotent transaction is planned for next alpha version